### PR TITLE
Improve error message + retry JSON Parsing error

### DIFF
--- a/lib/stream_lines/reading/stream.rb
+++ b/lib/stream_lines/reading/stream.rb
@@ -8,7 +8,7 @@ module StreamLines
     class Stream
       include Enumerable
 
-      def initialize(url, encoding: Encoding.default_external, chunk_size: nil, read_timeout: 10)
+      def initialize(url, encoding: Encoding.default_external, chunk_size: nil, read_timeout: 90)
         @url = url
         @encoding = encoding
         @buffer = String.new(encoding: @encoding)


### PR DESCRIPTION
When a crash happens, retry from the last chunk that was properly parsed, instead of continuing from where it left